### PR TITLE
Возврат null в случае пустого ответа

### DIFF
--- a/src/ITMH/Soap/Mapper.php
+++ b/src/ITMH/Soap/Mapper.php
@@ -44,6 +44,10 @@ class Mapper
             return $data;
         }
 
+        if ($this->isEmptyObject($data)) {
+            return null;
+        }
+
         $class = $this->getTargetClass($method);
         if (empty($class)) {
             return $data;
@@ -267,5 +271,23 @@ class Mapper
         if (!class_exists($className)) {
             throw new InvalidClassMappingException('Class not found: "' . $className . '"');
         }
+    }
+
+    /**
+     * Проверяет есть ли у объекта какие-либо публичные свойства
+     *
+     * @param $object
+     *
+     * @return bool
+     */
+    protected function isEmptyObject($object) {
+        if (is_object($object)) {
+            $vars = get_object_vars($object);
+            if(count($vars) === 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/ITMH/Soap/Mapper.php
+++ b/src/ITMH/Soap/Mapper.php
@@ -30,8 +30,8 @@ class Mapper
     /**
      * Разворачивает запрос если указан корневой элемент и осуществляет маппинг, если указан класс
      *
-     * @param $method
-     * @param $data
+     * @param string $method Имя метода
+     * @param mixed  $data   Данные
      *
      * @return array|mixed
      * @throws \ITMH\Soap\Exception\InvalidParameterException
@@ -44,7 +44,7 @@ class Mapper
             return $data;
         }
 
-        if ($this->isEmptyObject($data)) {
+        if (empty($data) || $this->isEmptyObject($data)) {
             return null;
         }
 
@@ -59,9 +59,9 @@ class Mapper
     /**
      * Производит маппинг данных в объект
      *
-     * @param mixed  $data     Данные для маппинга
-     * @param string $class    Полное имя класса для маппинга
-     * @param string $method   Имя ноды в которой находятся данные для маппинга
+     * @param mixed  $data   Данные для маппинга
+     * @param string $class  Полное имя класса для маппинга
+     * @param string $method Имя ноды в которой находятся данные для маппинга
      *
      * @return array|mixed
      * @throws \ITMH\Soap\Exception\MissingItemException
@@ -87,9 +87,9 @@ class Mapper
      * Производит маппинг атрибутов объекта учитывая карту атрибута,
      * если класс имплементирует интерфейс MappingInterface
      *
-     * @param $object
-     * @param $class
-     * @param $method
+     * @param mixed  $object Объект с данными
+     * @param string $class  Имя класса
+     * @param string $method Имя метода
      *
      * @return mixed
      * @throws \ITMH\Soap\Exception\InvalidClassMappingException
@@ -153,6 +153,7 @@ class Mapper
             $keys = array_keys(get_object_vars($data));
             if (count($keys) === 1) {
                 $rootClassName = reset($keys);
+
                 return $data->$rootClassName;
             }
 
@@ -276,14 +277,15 @@ class Mapper
     /**
      * Проверяет есть ли у объекта какие-либо публичные свойства
      *
-     * @param $object
+     * @param mixed $object Объект
      *
      * @return bool
      */
-    protected function isEmptyObject($object) {
+    protected function isEmptyObject($object)
+    {
         if (is_object($object)) {
             $vars = get_object_vars($object);
-            if(count($vars) === 0) {
+            if (count($vars) === 0) {
                 return true;
             }
         }

--- a/src/ITMH/Soap/Mapper.php
+++ b/src/ITMH/Soap/Mapper.php
@@ -45,7 +45,7 @@ class Mapper
         }
 
         if (empty($data) || $this->isEmptyObject($data)) {
-            return null;
+            return $this->isAsArray($method) ? [] : null;
         }
 
         $class = $this->getTargetClass($method);
@@ -53,7 +53,8 @@ class Mapper
             return $data;
         }
 
-        return $this->mapData($data, $class, $method);
+        $data = $this->mapData($data, $class, $method);
+        return $this->isAsArray($method) ? $this->toArray($data) : $data;
     }
 
     /**
@@ -65,9 +66,11 @@ class Mapper
      *
      * @return array|mixed
      * @throws \ITMH\Soap\Exception\MissingItemException
+     * @throws \ITMH\Soap\Exception\InvalidClassMappingException
      */
     public function mapData($data, $class, $method)
     {
+        $result = '';
         if (is_array($data)) {
             $result = [];
             foreach ($data as $item) {
@@ -172,11 +175,11 @@ class Mapper
      *
      * @param string $method Имя метода
      *
-     * @return string
+     * @return bool
      */
-    protected function getAsArray($method)
+    protected function isAsArray($method)
     {
-        return $this->getMethodConfigKey($method, 'asArray');
+        return (bool)$this->getMethodConfigKey($method, 'asArray');
     }
 
     /**
@@ -291,5 +294,21 @@ class Mapper
         }
 
         return false;
+    }
+
+    /**
+     * Оборачивает данные в массив, если они не являются массивом
+     *
+     * @param mixed $data Данные
+     *
+     * @return array
+     */
+    protected function toArray($data)
+    {
+        if (empty($data)) {
+            return [];
+        }
+
+        return is_array($data) ? $data : [$data];
     }
 }


### PR DESCRIPTION
Добавлена опция asArray в конфигах;
Если ранее при маппинге в таких случаях возвращался объект с пустыми полями, то теперь возвращается `null|[]`.
